### PR TITLE
Send gRPC error details also

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## HEAD
 
+## v0.1.1 (2018-10-03)
+
+### Enhancement
+
+- [Added](https://github.com/mercari/grpc-http-proxy/pull/5) Send gRPC error details in JSON response.  
+
 ## v0.1.0 (2018-09-14)
 
 Initial Release

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 
+	any "github.com/golang/protobuf/ptypes/any"
 	"google.golang.org/grpc/codes"
 )
 
@@ -101,8 +102,9 @@ func (e *ProxyError) WriteJSON(w io.Writer) error {
 
 // GRPCError is an error returned by gRPC upstream
 type GRPCError struct {
-	StatusCode int    `json:"code"`
-	Message    string `json:"message"`
+	StatusCode int        `json:"code"`
+	Message    string     `json:"message"`
+	Details    []*any.Any `json:"details,omitempty"`
 }
 
 // HTTPStatusCode converts gRPC status codes to HTTP status codes

--- a/proxy/stub/stub.go
+++ b/proxy/stub/stub.go
@@ -64,6 +64,7 @@ func (s *stubImpl) InvokeRPC(
 		return nil, &errors.GRPCError{
 			StatusCode: int(stat.Code()),
 			Message:    stat.Message(),
+			Details:    stat.Proto().Details,
 		}
 	}
 	outputMsg := invocation.MethodDescriptor.GetOutputType().NewMessage()


### PR DESCRIPTION
Please read the CLA carefully before submitting your contribution to Mercari.
Under any circumstances, by submitting your contribution, you are deemed to accept and agree to be bound by the terms and conditions of the CLA.

https://www.mercari.com/cla/

## WHAT
Send gRPC error details

## WHY
Currently, error details are not being sent in response. Only message & status code is sent. 

