### PR TITLE
Close http connection once request is done

### DIFF
--- a/http/handlers.go
+++ b/http/handlers.go
@@ -73,8 +73,11 @@ func (s *Server) RPCCallHandler(newClient func() Client) http.HandlerFunc {
 			returnError(w, errors.Cause(err).(perrors.Error))
 			return
 		}
+		// TODO: Re-Use connections instead of creating a new connection for each request.
 		client := newClient()
 		client.Connect(ctx, u)
+		defer client.CloseConn()
+
 		md := make(metadata.Metadata)
 
 		inputMessage, err := ioutil.ReadAll(r.Body)


### PR DESCRIPTION
Please read the CLA carefully before submitting your contribution to Mercari.
Under any circumstances, by submitting your contribution, you are deemed to accept and agree to be bound by the terms and conditions of the CLA.

https://www.mercari.com/cla/

## WHAT
Close http connection once request is finished. 

## WHY
In current grpc-http-proxy implementation, proxy creates a new connection to upstream for each requests. This is not efficient design as creating new connection is an expensive process. Plus, many upstream services enable Keepalive, this makes lots of zombie connections and put extra loads on upstream services. 

Although, this fix does not solve complete problem, but this will solve zombie connection problem by closing connection once request is complete. 

