### PR TITLE
🌟feat(responseTrailers): support for response header trailers added

### DIFF
--- a/http/handlers.go
+++ b/http/handlers.go
@@ -86,7 +86,7 @@ func (s *Server) RPCCallHandler(newClient func() Client) http.HandlerFunc {
 			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
-		response, err := client.Call(ctx, c.Service, c.Method, inputMessage, &md)
+		response, responseTrailer, err := client.Call(ctx, c.Service, c.Method, inputMessage, &md)
 		if err != nil {
 			returnError(w, errors.Cause(err).(perrors.Error))
 			s.logger.Error("error in handling call",
@@ -95,6 +95,10 @@ func (s *Server) RPCCallHandler(newClient func() Client) http.HandlerFunc {
 		}
 
 		w.Header().Set("Content-Type", "application/json")
+		for key, val := range responseTrailer {
+			w.Header().Set(key, val[0])
+		}
+
 		w.WriteHeader(http.StatusOK)
 		w.Write(response)
 		return

--- a/http/server.go
+++ b/http/server.go
@@ -2,13 +2,12 @@ package http
 
 import (
 	"context"
+	"github.com/mercari/grpc-http-proxy/metadata"
+	"go.uber.org/zap"
+	grpc_metadata "google.golang.org/grpc/metadata"
 	"net"
 	"net/http"
 	"net/url"
-
-	"go.uber.org/zap"
-
-	"github.com/mercari/grpc-http-proxy/metadata"
 )
 
 // Server is an grpc-http-proxy server
@@ -56,7 +55,7 @@ type Client interface {
 		string,
 		[]byte,
 		*metadata.Metadata,
-	) ([]byte, error)
+	) ([]byte, grpc_metadata.MD, error)
 }
 
 // Discoverer performs service discover

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -1,9 +1,12 @@
 package metadata
 
-import "strings"
+import (
+	"github.com/mercari/grpc-http-proxy/utils"
+	"strings"
+)
 
 // This is from an old grpc-gateway (https://github.com/grpc-ecosystem/grpc-gateway) specification
-const metadataHeaderPrefix = "Grpc-Metadata-"
+var metadataHeaderPrefix = utils.GetEnvVar( "GRPC_HEADER_METADATA_KEY_ID", "Grpc-Metadata-")
 
 // Metadata is gRPC metadata sent to and from upstream
 type Metadata map[string][]string

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -2,22 +2,21 @@ package proxy
 
 import (
 	"context"
-	"net/url"
-
 	"github.com/jhump/protoreflect/dynamic/grpcdynamic"
 	"github.com/jhump/protoreflect/grpcreflect"
-	"github.com/pkg/errors"
-	"google.golang.org/grpc"
-	rpb "google.golang.org/grpc/reflection/grpc_reflection_v1alpha"
-
 	"github.com/mercari/grpc-http-proxy/metadata"
 	"github.com/mercari/grpc-http-proxy/proxy/reflection"
 	pstub "github.com/mercari/grpc-http-proxy/proxy/stub"
+	"github.com/pkg/errors"
+	"google.golang.org/grpc"
+	grpc_metadata "google.golang.org/grpc/metadata"
+	rpb "google.golang.org/grpc/reflection/grpc_reflection_v1alpha"
+	"net/url"
 )
 
 // Proxy is a dynamic gRPC client that performs reflection
 type Proxy struct {
-	cc        *grpc.ClientConn
+	conn      *grpc.ClientConn
 	reflector reflection.Reflector
 	stub      pstub.Stub
 }
@@ -29,20 +28,20 @@ func NewProxy() *Proxy {
 
 // Connect opens a connection to target.
 func (p *Proxy) Connect(ctx context.Context, target *url.URL) error {
-	cc, err := grpc.DialContext(ctx, target.String(), grpc.WithInsecure())
+	conn, err := grpc.DialContext(ctx, target.String(), grpc.WithInsecure())
 	if err != nil {
 		return err
 	}
-	p.cc = cc
-	rc := grpcreflect.NewClient(ctx, rpb.NewServerReflectionClient(p.cc))
+	p.conn = conn
+	rc := grpcreflect.NewClient(ctx, rpb.NewServerReflectionClient(p.conn))
 	p.reflector = reflection.NewReflector(rc)
-	p.stub = pstub.NewStub(grpcdynamic.NewStub(p.cc))
+	p.stub = pstub.NewStub(grpcdynamic.NewStub(p.conn))
 	return err
 }
 
 // CloseConn closes the underlying connection
 func (p *Proxy) CloseConn() error {
-	return p.cc.Close()
+	return p.conn.Close()
 }
 
 // Call performs the gRPC call after doing reflection to obtain type information
@@ -50,19 +49,22 @@ func (p *Proxy) Call(ctx context.Context,
 	serviceName, methodName string,
 	message []byte,
 	md *metadata.Metadata,
-) ([]byte, error) {
+) ([]byte, grpc_metadata.MD, error) {
 	invocation, err := p.reflector.CreateInvocation(ctx, serviceName, methodName, message)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	outputMsg, err := p.stub.InvokeRPC(ctx, invocation, md)
+	outputMsg, responseTrailer, err := p.stub.InvokeRPC(ctx, invocation, md)
+
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
+
 	m, err := outputMsg.MarshalJSON()
+
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to marshal output JSON")
+		return nil, nil, errors.Wrap(err, "failed to marshal output JSON")
 	}
-	return m, err
+	return m, responseTrailer, err
 }

--- a/proxy/stub/stub.go
+++ b/proxy/stub/stub.go
@@ -3,17 +3,15 @@ package stub
 import (
 	"context"
 	"fmt"
-
 	"github.com/golang/protobuf/proto"
 	"github.com/jhump/protoreflect/desc"
+	"github.com/mercari/grpc-http-proxy/errors"
+	"github.com/mercari/grpc-http-proxy/metadata"
+	"github.com/mercari/grpc-http-proxy/proxy/reflection"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	grpc_metadata "google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
-
-	"github.com/mercari/grpc-http-proxy/errors"
-	"github.com/mercari/grpc-http-proxy/metadata"
-	"github.com/mercari/grpc-http-proxy/proxy/reflection"
 )
 
 // Stub performs gRPC calls based on descriptors obtained through reflection
@@ -23,7 +21,7 @@ type Stub interface {
 	InvokeRPC(
 		ctx context.Context,
 		invocation *reflection.MethodInvocation,
-		md *metadata.Metadata) (reflection.Message, error)
+		md *metadata.Metadata) (reflection.Message, grpc_metadata.MD, error)
 }
 
 type stubImpl struct {
@@ -45,37 +43,43 @@ func NewStub(s grpcdynamicStub) Stub {
 func (s *stubImpl) InvokeRPC(
 	ctx context.Context,
 	invocation *reflection.MethodInvocation,
-	md *metadata.Metadata) (reflection.Message, error) {
+	md *metadata.Metadata) (reflection.Message, grpc_metadata.MD, error) {
 
-	o, err := s.stub.InvokeRpc(ctx,
+	var responseTrailer grpc_metadata.MD // variable to store responseTrailer
+
+	message, err := s.stub.InvokeRpc(ctx,
 		invocation.MethodDescriptor.AsProtoreflectDescriptor(),
 		invocation.Message.AsProtoreflectMessage(),
-		grpc.Header((*grpc_metadata.MD)(md)))
+		grpc.Header((*grpc_metadata.MD)(md)),
+		grpc.Trailer(&responseTrailer))
+
 	if err != nil {
 		stat := status.Convert(err)
+
 		if err != nil && stat.Code() == codes.Unavailable {
-			return nil, &errors.ProxyError{
+			return nil, nil, &errors.ProxyError{
 				Code:    errors.UpstreamConnFailure,
 				Message: fmt.Sprintf("could not connect to backend"),
 			}
 		}
 
 		// When InvokeRPC returns an error, it should always be a gRPC error, so this should not panic
-		return nil, &errors.GRPCError{
+		return nil, nil, &errors.GRPCError{
 			StatusCode: int(stat.Code()),
 			Message:    stat.Message(),
 			Details:    stat.Proto().Details,
 		}
 	}
-	outputMsg := invocation.MethodDescriptor.GetOutputType().NewMessage()
-	err = outputMsg.ConvertFrom(o)
+
+  	outputMsg := invocation.MethodDescriptor.GetOutputType().NewMessage()
+	err = outputMsg.ConvertFrom(message)
 
 	if err != nil {
-		return nil, &errors.ProxyError{
+		return nil, nil, &errors.ProxyError{
 			Code:    errors.Unknown,
 			Message: "response from backend could not be converted internally; this is a bug",
 		}
 	}
 
-	return outputMsg, nil
+	return outputMsg, responseTrailer, nil
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -1,0 +1,19 @@
+/*
+* created by Roman Zhyliov <roman@kintohub.com>
+*/
+
+package utils
+
+import (
+    "os"
+)
+
+func GetEnvVar(key, fallback string) string {
+
+    returnVal := fallback
+
+    if value, ok := os.LookupEnv(key); ok {
+        returnVal = value
+    }
+    return returnVal
+}


### PR DESCRIPTION
+ plus GRPC_HEADER_METADATA_KEY_ID to config Grpc-Metadata headers key

Please read the CLA carefully before submitting your contribution to Mercari.
Under any circumstances, by submitting your contribution, you are deemed to accept and agree to be bound by the terms and conditions of the CLA.

https://www.mercari.com/cla/

## WHAT
Update allowing to receive back headers from the grpc call processing result.
plus ability to specify Grpc-Metadata- header key for incoming headers using an environment variable instead of constant value.
plus small updates to names as it was confusing to read the code a bit.

## WHY
While translation is working great which is awesome! But the biggest issue for us when we were assessing the concept with your repo was the fact that we were not receiving any headers back from the rpc call result. Obviously the header trailers should be returned back to the caller, as they might contain new/updated data that client requires back.

